### PR TITLE
Add color to notify-send

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje-notifier "0.2.0"
+(defproject midje-notifier "0.2.1"
   :description "Growl and libnotify output for Midje"
   :url "http://github.com/glittershark/midje-notifier"
   :license {:name "MIT License"

--- a/src/midje/notifier.clj
+++ b/src/midje/notifier.clj
@@ -2,28 +2,47 @@
   (:require [robert.hooke :refer [with-scope append]]
             [clojure.java.shell :refer [sh]]))
 
-(defmacro exists? [program] `(= 0 (:exit (sh "which" ~program))))
+(defn exists? [program]
+  (->> program
+       (sh "which")
+       :exit
+       (= 0)))
 
 (defonce notification-type
   (cond
     (exists? "notify-send")       :notify-send
     (exists? "terminal-notifier") :terminal-notifier))
 
-(defmacro notify-send [title body]
-  (case notification-type
-    :notify-send       `(sh "notify-send" ~title ~body)
-    :terminal-notifier `(sh ":terminal-notifier" "-message" ~body "-title" ~title)))
+(defmulti send-notification (constantly notification-type))
+
+(defmethod send-notification :notify-send
+  [title body & {:keys [pass?]}]
+  (sh "notify-send"
+      "-h" (str "string:bgcolor:"(if pass? "#008800" "#ff4444"))
+      title body))
+
+(defmethod send-notification :terminal-notifier
+  [title body & {:keys [pass?]}]
+  ;; FIXME pass? is ignored, some iPerson please add some visual indicator of pass/fail
+  (sh "terminal-notifier" "-message" body "-title" title))
+
+(defmethod send-notification :default
+  [title body & {:keys [pass?]}]
+  (println "Unable to send notification, do you have either terminal-notifier or notify-send on your $PATH?")
+  (println title body pass?))
 
 (defn send-notifications []
   (let [{passes :midje-passes failures :midje-failures}
         (midje.emission.state/output-counters)]
-    (notify-send
-      "Tests complete"
-      (if (= 0 failures)
-        (str "All checks (" passes ") succeeded.")
-        (str failures " checks failed, " passes " succeeded")))))
+    (let [passed (= 0 failures)]
+      (send-notification
+       "Tests complete"
+       (if passed
+         (str "All checks (" passes ") succeeded.")
+         (str failures " checks failed, " passes " succeeded"))
+       :pass? passed))))
 
-(defmacro notify-me
-  "Send notifications using notify-send about all successive Midje test results"
+(defn notify-me
+  "Send notifications using notify-send or terminal-notifier after each Midje test run"
   []
-  `(append midje.emission.api/fact-stream-summary (send-notifications)))
+  (append midje.emission.api/fact-stream-summary (send-notifications)))


### PR DESCRIPTION
Hi! I wrote this out of necessity, I need my notify-send messages to show up with a background-color depending on whether any tests failed.

I also refactored a little bit.

I didn't add the same for terminal-notifier, but it should be easy to do so.
